### PR TITLE
Updates and fixes specs

### DIFF
--- a/spec/armor_payments/api/accounts_spec.rb
+++ b/spec/armor_payments/api/accounts_spec.rb
@@ -8,18 +8,18 @@ module ArmorPayments
 
     describe "#uri" do
       it "returns '/accounts' if given no id" do
-        accounts.uri.should == '/accounts'
+        expect(accounts.uri).to eq '/accounts'
       end
 
       it "returns '/accounts/:id' if given an id" do
-        accounts.uri(456).should == '/accounts/456'
+        expect(accounts.uri(456)).to eq '/accounts/456'
       end
     end
 
     describe "#create" do
 
       it "makes POST with /accounts and JSONified data" do
-        accounts.should_receive(:request).with( :post, hash_including(path: '/accounts', body: '{"name":"Bobby Lee"}'))
+        expect(accounts).to receive(:request).with( :post, hash_including(path: '/accounts', body: '{"name":"Bobby Lee"}'))
         accounts.create({ 'name' => 'Bobby Lee'})
       end
 

--- a/spec/armor_payments/api/disputes_spec.rb
+++ b/spec/armor_payments/api/disputes_spec.rb
@@ -8,11 +8,11 @@ module ArmorPayments
 
     describe "#uri" do
       it "returns '/accounts/:aid/orders/:oid/disputes' if given no id" do
-        disputes.uri.should == '/accounts/1234/orders/56/disputes'
+        expect(disputes.uri).to eq '/accounts/1234/orders/56/disputes'
       end
 
       it "returns '/accounts/:aid/disputes/:dispute_id' if given an id" do
-        disputes.uri(78).should == '/accounts/1234/orders/56/disputes/78'
+        expect(disputes.uri(78)).to eq '/accounts/1234/orders/56/disputes/78'
       end
     end
 

--- a/spec/armor_payments/api/documents_spec.rb
+++ b/spec/armor_payments/api/documents_spec.rb
@@ -9,7 +9,7 @@ module ArmorPayments
     describe "#create" do
 
       it "makes POST with the right uri and JSONified data" do
-        documents.should_receive(:request).with( :post, hash_including(path: '/accounts/123/orders/456/documents', body: '{"name":"Bobby Lee"}'))
+        expect(documents).to receive(:request).with( :post, hash_including(path: '/accounts/123/orders/456/documents', body: '{"name":"Bobby Lee"}'))
         documents.create({ 'name' => 'Bobby Lee'})
       end
 

--- a/spec/armor_payments/api/notes_spec.rb
+++ b/spec/armor_payments/api/notes_spec.rb
@@ -9,7 +9,7 @@ module ArmorPayments
     describe "#create" do
 
       it "makes POST with the right uri and JSONified data" do
-        notes.should_receive(:request).with( :post, hash_including(path: '/accounts/123/orders/456/notes', body: '{"name":"Bobby Lee"}'))
+        expect(notes).to receive(:request).with( :post, hash_including(path: '/accounts/123/orders/456/notes', body: '{"name":"Bobby Lee"}'))
         notes.create({ 'name' => 'Bobby Lee'})
       end
 

--- a/spec/armor_payments/api/offers_spec.rb
+++ b/spec/armor_payments/api/offers_spec.rb
@@ -8,7 +8,7 @@ module ArmorPayments
 
     describe "#update" do
       it "makes POST with the right uri and JSONified data" do
-        offers.should_receive(:request).with(
+        expect(offers).to receive(:request).with(
           :post,
           hash_including(path: '/accounts/1234/offers/90', body: '{"name":"Bobby Lee"}')
         )

--- a/spec/armor_payments/api/orders_spec.rb
+++ b/spec/armor_payments/api/orders_spec.rb
@@ -8,17 +8,17 @@ module ArmorPayments
 
     describe "#uri" do
       it "returns '/accounts/:aid/orders' if given no id" do
-        orders.uri.should == '/accounts/1234/orders'
+        expect(orders.uri).to eq '/accounts/1234/orders'
       end
 
       it "returns '/accounts/:aid/orders/:order_id' if given an id" do
-        orders.uri(456).should == '/accounts/1234/orders/456'
+        expect(orders.uri(456)).to eq '/accounts/1234/orders/456'
       end
     end
 
     describe "#update" do
       it "makes POST with the right uri and JSONified data" do
-        orders.should_receive(:request).with(
+        expect(orders).to receive(:request).with(
           :post,
           hash_including(path: '/accounts/1234/orders/90', body: '{"name":"Bobby Lee"}')
         )

--- a/spec/armor_payments/api/resource_spec.rb
+++ b/spec/armor_payments/api/resource_spec.rb
@@ -32,21 +32,23 @@ module ArmorPayments
           failed_response = Excon::Response.new(status: 502, body: 'Gateway Timeout')
           resource.connection.stub(:get).and_return(failed_response)
           response = resource.request('get', {})
-          response.body.should == 'Gateway Timeout'
+          expect(response.body).to eq 'Gateway Timeout'
         end
       end
     end
 
     context "smoketest" do
+      let(:time) { Time.new(2014, 2, 22, 12, 0, 0, "+00:00") }
+
       describe "#all" do
         it "queries the host for all of the resources, with approprate headers" do
-          Timecop.freeze(2014, 2, 22, 12, 0, 0) do
-            resource.connection.should_receive(:get).with({
+          Timecop.freeze(time) do
+            expect(resource.connection).to receive(:get).with({
               path: '/wibble/123/resource',
               headers: {
-                "X_ARMORPAYMENTS_APIKEY"            => "my-api-key",
-                "X_ARMORPAYMENTS_REQUESTTIMESTAMP"  => "2014-02-22T17:00:00Z",
-                "X_ARMORPAYMENTS_SIGNATURE"         => "ec41629dc204b449c71bf89d1be4630f5353e37869197f5a926539f6fc676ebcccdb5426fb3f01a01fa7dc9551d38d152e41294a5147b15e460d09ff60cf1562"
+                "x-armorpayments-apikey"            => "my-api-key",
+                "x-armorpayments-requesttimestamp"  => "2014-02-22T12:00:00Z",
+                "x-armorpayments-signature"         => "ec41629dc204b449c71bf89d1be4630f5353e37869197f5a926539f6fc676ebcccdb5426fb3f01a01fa7dc9551d38d152e41294a5147b15e460d09ff60cf1562"
               }
             }).and_return(successful_response)
 
@@ -57,13 +59,13 @@ module ArmorPayments
 
       describe "#get" do
         it "queries the host for a specific resource, with approprate headers" do
-          Timecop.freeze(2014, 2, 22, 12, 0, 0) do
-            resource.connection.should_receive(:get).with({
+          Timecop.freeze(time) do
+            expect(resource.connection).to receive(:get).with({
               path: '/wibble/123/resource/456',
               headers: {
-                "X_ARMORPAYMENTS_APIKEY"            => "my-api-key",
-                "X_ARMORPAYMENTS_REQUESTTIMESTAMP"  => "2014-02-22T17:00:00Z",
-                "X_ARMORPAYMENTS_SIGNATURE"         => "48886620cfebb95ffd9ee351f4f68d4f103a8f4bdc0e3301f7ee709ec2cf3c19588ae1b67aa8ee38305de802651fb10093cf1af40f467ac936185d551a58a844"
+                "x-armorpayments-apikey"            => "my-api-key",
+                "x-armorpayments-requesttimestamp"  => "2014-02-22T12:00:00Z",
+                "x-armorpayments-signature"         => "48886620cfebb95ffd9ee351f4f68d4f103a8f4bdc0e3301f7ee709ec2cf3c19588ae1b67aa8ee38305de802651fb10093cf1af40f467ac936185d551a58a844"
               }
             }).and_return(successful_response)
 

--- a/spec/armor_payments/api/resource_spec.rb
+++ b/spec/armor_payments/api/resource_spec.rb
@@ -49,7 +49,7 @@ module ArmorPayments
               path: '/wibble/123/resource',
               headers: {
                 "x-armorpayments-apikey"            => "my-api-key",
-                "x-armorpayments-requesttimestamp"  => "2014-02-22T12:00:00Z",
+                "x-armorpayments-requesttimestamp"  => given_time.utc.iso8601,
                 "x-armorpayments-signature"         => Digest::SHA512.hexdigest("#{api_secret}:GET:/wibble/123/resource:#{given_time.utc.iso8601}")
               }
             }).and_return(successful_response)
@@ -66,7 +66,7 @@ module ArmorPayments
               path: '/wibble/123/resource/456',
               headers: {
                 "x-armorpayments-apikey"            => "my-api-key",
-                "x-armorpayments-requesttimestamp"  => "2014-02-22T12:00:00Z",
+                "x-armorpayments-requesttimestamp"  => given_time.utc.iso8601,
                 "x-armorpayments-signature"         => Digest::SHA512.hexdigest("#{api_secret}:GET:/wibble/123/resource/456:#{given_time.utc.iso8601}")
               }
             }).and_return(successful_response)

--- a/spec/armor_payments/api/resource_spec.rb
+++ b/spec/armor_payments/api/resource_spec.rb
@@ -10,11 +10,11 @@ module ArmorPayments
 
     describe "#uri" do
       it "returns '/%{uri_root}/resource_name' if given no id" do
-        resource.uri.should == '/wibble/123/resource'
+        expect(resource.uri).to eq '/wibble/123/resource'
       end
 
       it "returns '/%{uri_root}/resource_name/:id' if given an id" do
-        resource.uri(456).should == '/wibble/123/resource/456'
+        expect(resource.uri(456)).to eq '/wibble/123/resource/456'
       end
     end
 
@@ -23,7 +23,7 @@ module ArmorPayments
         it "returns the parsed JSON body" do
           resource.connection.stub(:get).and_return(successful_response)
           response = resource.request('get', {})
-          response.body.should == { 'whee' => 42 }
+          expect(response.body).to eq 'whee' => 42
         end
       end
 

--- a/spec/armor_payments/api/resource_spec.rb
+++ b/spec/armor_payments/api/resource_spec.rb
@@ -2,7 +2,9 @@ require 'spec_helper'
 
 module ArmorPayments
   describe Resource do
-    let(:authenticator) { Authenticator.new('my-api-key', 'my-secret-code') }
+    let(:api_key) { 'my-api-key' }
+    let(:api_secret) { 'my-secret-code' }
+    let(:authenticator) { Authenticator.new(api_key, api_secret) }
     let(:host) { 'https://sandbox.armorpayments.com' }
     let(:uri_root) { '/wibble/123' }
     let(:resource) { Resource.new(host, authenticator, uri_root) }
@@ -48,7 +50,7 @@ module ArmorPayments
               headers: {
                 "x-armorpayments-apikey"            => "my-api-key",
                 "x-armorpayments-requesttimestamp"  => "2014-02-22T12:00:00Z",
-                "x-armorpayments-signature"         => "ec41629dc204b449c71bf89d1be4630f5353e37869197f5a926539f6fc676ebcccdb5426fb3f01a01fa7dc9551d38d152e41294a5147b15e460d09ff60cf1562"
+                "x-armorpayments-signature"         => Digest::SHA512.hexdigest("#{api_secret}:GET:/wibble/123/resource:#{Time.now.utc.iso8601}")
               }
             }).and_return(successful_response)
 
@@ -65,7 +67,7 @@ module ArmorPayments
               headers: {
                 "x-armorpayments-apikey"            => "my-api-key",
                 "x-armorpayments-requesttimestamp"  => "2014-02-22T12:00:00Z",
-                "x-armorpayments-signature"         => "48886620cfebb95ffd9ee351f4f68d4f103a8f4bdc0e3301f7ee709ec2cf3c19588ae1b67aa8ee38305de802651fb10093cf1af40f467ac936185d551a58a844"
+                "x-armorpayments-signature"         => Digest::SHA512.hexdigest("#{api_secret}:GET:/wibble/123/resource/456:#{Time.now.utc.iso8601}")
               }
             }).and_return(successful_response)
 

--- a/spec/armor_payments/api/resource_spec.rb
+++ b/spec/armor_payments/api/resource_spec.rb
@@ -21,7 +21,7 @@ module ArmorPayments
     describe "#request" do
       context "on a response with a JSON body" do
         it "returns the parsed JSON body" do
-          resource.connection.stub(:get).and_return(successful_response)
+          allow(resource.connection).to receive(:get).and_return(successful_response)
           response = resource.request('get', {})
           expect(response.body).to eq 'whee' => 42
         end
@@ -30,7 +30,7 @@ module ArmorPayments
       context "on a response without JSON" do
         it "returns the full response object" do
           failed_response = Excon::Response.new(status: 502, body: 'Gateway Timeout')
-          resource.connection.stub(:get).and_return(failed_response)
+          allow(resource.connection).to receive(:get).and_return(failed_response)
           response = resource.request('get', {})
           expect(response.body).to eq 'Gateway Timeout'
         end

--- a/spec/armor_payments/api/resource_spec.rb
+++ b/spec/armor_payments/api/resource_spec.rb
@@ -40,17 +40,17 @@ module ArmorPayments
     end
 
     context "smoketest" do
-      let(:time) { Time.new(2014, 2, 22, 12, 0, 0, "+00:00") }
+      let(:given_time) { Time.new(2014, 2, 22, 12, 0, 0, "+00:00") }
 
       describe "#all" do
         it "queries the host for all of the resources, with approprate headers" do
-          Timecop.freeze(time) do
+          Timecop.freeze(given_time) do
             expect(resource.connection).to receive(:get).with({
               path: '/wibble/123/resource',
               headers: {
                 "x-armorpayments-apikey"            => "my-api-key",
                 "x-armorpayments-requesttimestamp"  => "2014-02-22T12:00:00Z",
-                "x-armorpayments-signature"         => Digest::SHA512.hexdigest("#{api_secret}:GET:/wibble/123/resource:#{Time.now.utc.iso8601}")
+                "x-armorpayments-signature"         => Digest::SHA512.hexdigest("#{api_secret}:GET:/wibble/123/resource:#{given_time.utc.iso8601}")
               }
             }).and_return(successful_response)
 
@@ -61,13 +61,13 @@ module ArmorPayments
 
       describe "#get" do
         it "queries the host for a specific resource, with approprate headers" do
-          Timecop.freeze(time) do
+          Timecop.freeze(given_time) do
             expect(resource.connection).to receive(:get).with({
               path: '/wibble/123/resource/456',
               headers: {
                 "x-armorpayments-apikey"            => "my-api-key",
                 "x-armorpayments-requesttimestamp"  => "2014-02-22T12:00:00Z",
-                "x-armorpayments-signature"         => Digest::SHA512.hexdigest("#{api_secret}:GET:/wibble/123/resource/456:#{Time.now.utc.iso8601}")
+                "x-armorpayments-signature"         => Digest::SHA512.hexdigest("#{api_secret}:GET:/wibble/123/resource/456:#{given_time.utc.iso8601}")
               }
             }).and_return(successful_response)
 

--- a/spec/armor_payments/api/users_spec.rb
+++ b/spec/armor_payments/api/users_spec.rb
@@ -8,11 +8,11 @@ module ArmorPayments
 
     describe "#uri" do
       it "returns '/users' if given no id" do
-        users.uri.should == '/accounts/1234/users'
+        expect(users.uri).to eq '/accounts/1234/users'
       end
 
       it "returns '/users/:id' if given an id" do
-        users.uri(456).should == '/accounts/1234/users/456'
+        expect(users.uri(456)).to eq '/accounts/1234/users/456'
       end
     end
 

--- a/spec/armor_payments/api/users_spec.rb
+++ b/spec/armor_payments/api/users_spec.rb
@@ -7,11 +7,11 @@ module ArmorPayments
     let(:users) { Users.new(host, authenticator, '/accounts/1234') }
 
     describe "#uri" do
-      it "returns '/users' if given no id" do
+      it "returns 'accounts/:aid/users' if given no id" do
         expect(users.uri).to eq '/accounts/1234/users'
       end
 
-      it "returns '/users/:id' if given an id" do
+      it "returns 'accounts/:aid/users/:id' if given an id" do
         expect(users.uri(456)).to eq '/accounts/1234/users/456'
       end
     end

--- a/spec/armor_payments/api_spec.rb
+++ b/spec/armor_payments/api_spec.rb
@@ -7,15 +7,15 @@ module ArmorPayments
     describe "#armor_host" do
       context "in sandbox mode" do
         it "returns https://sandbox.armorpayments.com" do
-          client.sandbox.should be_true
-          client.armor_host.should == "https://sandbox.armorpayments.com"
+          expect(client.sandbox).to be true
+          expect(client.armor_host).to eq "https://sandbox.armorpayments.com"
         end
       end
 
       context "*not* in sandbox mode" do
         it "returns https://api.armorpayments.com" do
           client.sandbox = false
-          client.armor_host.should == "https://api.armorpayments.com"
+          expect(client.armor_host).to eq "https://api.armorpayments.com"
         end
       end
     end

--- a/spec/armor_payments/authenticator_spec.rb
+++ b/spec/armor_payments/authenticator_spec.rb
@@ -4,45 +4,47 @@ require 'armor_payments/authenticator'
 module ArmorPayments
   describe Authenticator do
     let(:authenticator) { Authenticator.new('my-api-key', 'my-secret-code') }
+    let(:time) { Time.new(2014, 2, 22, 12, 0, 0, "+00:00") }
 
     describe "#current_timestamp" do
       it "returns the current time in iso8601 format" do
-        Timecop.freeze(2014, 2, 22, 12, 0, 0) do
-          authenticator.current_timestamp.should == '2014-02-22T17:00:00Z'
+        Timecop.freeze(time) do
+          expect(authenticator.current_timestamp).to eq '2014-02-22T12:00:00Z'
         end
       end
     end
 
     describe "#request_signature" do
       it "hands a concatenated string encompassing the secret, request method, uri, and date to the digest service" do
-        Timecop.freeze(2014, 2, 22, 12, 0, 0) do
+        Timecop.freeze(time) do
           the_beast = "#{authenticator.api_secret}:GET:/accounts:#{authenticator.current_timestamp}"
-          Digest::SHA512.should_receive(:hexdigest).with(the_beast)
+          expect(Digest::SHA512).to receive(:hexdigest).with(the_beast)
           authenticator.request_signature('get', '/accounts')
         end
       end
 
       it "returns a SHA512 hash value" do
-        Timecop.freeze(2014, 2, 22, 12, 0, 0) do
-          authenticator.request_signature("get", "/accounts").should ==
+        Timecop.freeze(time) do
+          expect(authenticator.request_signature("get", "/accounts")).to eq(
             "777990373678937074c1b357d632e0ea3439d0e834e573c03076ee557f526565f9ac2b38483b3e41024b96ec2644d60b4f70f0d9c760b2ebeb9827f9b335d069"
+          )
         end
       end
     end
 
     describe "#secure_headers" do
       it "returns a hash with the required headers in" do
-        required_headers = %w( X_ARMORPAYMENTS_APIKEY X_ARMORPAYMENTS_REQUESTTIMESTAMP X_ARMORPAYMENTS_SIGNATURE )
-        authenticator.secure_headers('get', '/accounts').keys.sort.should == required_headers.sort
+        required_headers = %w( x-armorpayments-apikey x-armorpayments-requesttimestamp x-armorpayments-signature )
+        expect(authenticator.secure_headers('get', '/accounts').keys.sort).to eq required_headers.sort
       end
 
       it "assigns the correct value for each of the headers" do
-        Timecop.freeze(2014, 2, 22, 12, 0, 0) do
-          authenticator.secure_headers('get', '/accounts').should == {
-            "X_ARMORPAYMENTS_APIKEY"            => "my-api-key",
-            "X_ARMORPAYMENTS_SIGNATURE"         => "777990373678937074c1b357d632e0ea3439d0e834e573c03076ee557f526565f9ac2b38483b3e41024b96ec2644d60b4f70f0d9c760b2ebeb9827f9b335d069",
-            "X_ARMORPAYMENTS_REQUESTTIMESTAMP"  => "2014-02-22T17:00:00Z"
-          }
+        Timecop.freeze(time) do
+          expect(authenticator.secure_headers('get', '/accounts')).to eq({
+            "x-armorpayments-apikey"            => "my-api-key",
+            "x-armorpayments-signature"         => "777990373678937074c1b357d632e0ea3439d0e834e573c03076ee557f526565f9ac2b38483b3e41024b96ec2644d60b4f70f0d9c760b2ebeb9827f9b335d069",
+            "x-armorpayments-requesttimestamp"  => "2014-02-22T12:00:00Z"
+          })
         end
       end
     end

--- a/spec/armor_payments/authenticator_spec.rb
+++ b/spec/armor_payments/authenticator_spec.rb
@@ -3,7 +3,9 @@ require 'armor_payments/authenticator'
 
 module ArmorPayments
   describe Authenticator do
-    let(:authenticator) { Authenticator.new('my-api-key', 'my-secret-code') }
+    let(:api_key) { 'my-api-key' }
+    let(:api_secret) { 'my-secret-code' }
+    let(:authenticator) { Authenticator.new(api_key, api_secret) }
     let(:time) { Time.new(2014, 2, 22, 12, 0, 0, "+00:00") }
 
     describe "#current_timestamp" do
@@ -26,7 +28,7 @@ module ArmorPayments
       it "returns a SHA512 hash value" do
         Timecop.freeze(time) do
           expect(authenticator.request_signature("get", "/accounts")).to eq(
-            "777990373678937074c1b357d632e0ea3439d0e834e573c03076ee557f526565f9ac2b38483b3e41024b96ec2644d60b4f70f0d9c760b2ebeb9827f9b335d069"
+            Digest::SHA512.hexdigest "#{api_secret}:GET:/accounts:#{Time.now.utc.iso8601}"
           )
         end
       end
@@ -41,8 +43,8 @@ module ArmorPayments
       it "assigns the correct value for each of the headers" do
         Timecop.freeze(time) do
           expect(authenticator.secure_headers('get', '/accounts')).to eq({
-            "x-armorpayments-apikey"            => "my-api-key",
-            "x-armorpayments-signature"         => "777990373678937074c1b357d632e0ea3439d0e834e573c03076ee557f526565f9ac2b38483b3e41024b96ec2644d60b4f70f0d9c760b2ebeb9827f9b335d069",
+            "x-armorpayments-apikey"            => api_key,
+            "x-armorpayments-signature"         => Digest::SHA512.hexdigest("#{api_secret}:GET:/accounts:#{Time.now.utc.iso8601}"),
             "x-armorpayments-requesttimestamp"  => "2014-02-22T12:00:00Z"
           })
         end

--- a/spec/armor_payments/authenticator_spec.rb
+++ b/spec/armor_payments/authenticator_spec.rb
@@ -45,7 +45,7 @@ module ArmorPayments
           expect(authenticator.secure_headers('get', '/accounts')).to eq({
             "x-armorpayments-apikey"            => api_key,
             "x-armorpayments-signature"         => Digest::SHA512.hexdigest("#{api_secret}:GET:/accounts:#{given_time.utc.iso8601}"),
-            "x-armorpayments-requesttimestamp"  => "2014-02-22T12:00:00Z"
+            "x-armorpayments-requesttimestamp"  => given_time.utc.iso8601
           })
         end
       end

--- a/spec/armor_payments/authenticator_spec.rb
+++ b/spec/armor_payments/authenticator_spec.rb
@@ -6,11 +6,11 @@ module ArmorPayments
     let(:api_key) { 'my-api-key' }
     let(:api_secret) { 'my-secret-code' }
     let(:authenticator) { Authenticator.new(api_key, api_secret) }
-    let(:time) { Time.new(2014, 2, 22, 12, 0, 0, "+00:00") }
+    let(:given_time) { Time.new(2014, 2, 22, 12, 0, 0, "+00:00") }
 
     describe "#current_timestamp" do
       it "returns the current time in iso8601 format" do
-        Timecop.freeze(time) do
+        Timecop.freeze(given_time) do
           expect(authenticator.current_timestamp).to eq '2014-02-22T12:00:00Z'
         end
       end
@@ -18,7 +18,7 @@ module ArmorPayments
 
     describe "#request_signature" do
       it "hands a concatenated string encompassing the secret, request method, uri, and date to the digest service" do
-        Timecop.freeze(time) do
+        Timecop.freeze(given_time) do
           the_beast = "#{authenticator.api_secret}:GET:/accounts:#{authenticator.current_timestamp}"
           expect(Digest::SHA512).to receive(:hexdigest).with(the_beast)
           authenticator.request_signature('get', '/accounts')
@@ -26,9 +26,9 @@ module ArmorPayments
       end
 
       it "returns a SHA512 hash value" do
-        Timecop.freeze(time) do
+        Timecop.freeze(given_time) do
           expect(authenticator.request_signature("get", "/accounts")).to eq(
-            Digest::SHA512.hexdigest "#{api_secret}:GET:/accounts:#{Time.now.utc.iso8601}"
+            Digest::SHA512.hexdigest "#{api_secret}:GET:/accounts:#{given_time.utc.iso8601}"
           )
         end
       end
@@ -41,10 +41,10 @@ module ArmorPayments
       end
 
       it "assigns the correct value for each of the headers" do
-        Timecop.freeze(time) do
+        Timecop.freeze(given_time) do
           expect(authenticator.secure_headers('get', '/accounts')).to eq({
             "x-armorpayments-apikey"            => api_key,
-            "x-armorpayments-signature"         => Digest::SHA512.hexdigest("#{api_secret}:GET:/accounts:#{Time.now.utc.iso8601}"),
+            "x-armorpayments-signature"         => Digest::SHA512.hexdigest("#{api_secret}:GET:/accounts:#{given_time.utc.iso8601}"),
             "x-armorpayments-requesttimestamp"  => "2014-02-22T12:00:00Z"
           })
         end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,7 +6,6 @@ Timecop.safe_mode = true
 
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
-  config.treat_symbols_as_metadata_keys_with_true_values = true
   config.run_all_when_everything_filtered = true
   config.filter_run :focus
 


### PR DESCRIPTION
- Updates to the 3.0+ RSpec `expect` syntax
- Fixes SHA generation specs, makes them more flexible
- Specifies UTC offset in Time object generation for comparison's sake
